### PR TITLE
Add initial level zero raytracing testing

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 sudo apt -y update
-sudo apt install -y build-essential cmake ocl-icd-libopencl1 libva2 libva-drm2 libze-dev libze-intel-gpu-dev libpng-dev libboost-all-dev libmfx-gen1
+sudo apt install -y build-essential cmake ocl-icd-libopencl1 libva2 libva-drm2 libze-dev libze-intel-gpu-dev libpng-dev libboost-all-dev libmfx-gen1 ninja-build
 
 git clone https://github.com/oneapi-src/level-zero-tests
 cd level-zero-tests
@@ -12,3 +12,26 @@ mkdir build
 cd build
 cmake -D CMAKE_INSTALL_PREFIX=/usr/local/checkbox-gfx ..
 sudo cmake --build . --config Release --target install
+
+# install level-zero-raytracing-support testing
+cd /usr/local/checkbox-gfx
+mkdir sycl_linux && cd sycl_linux
+wget https://github.com/intel/llvm/releases/download/nightly-2024-06-10/sycl_linux.tar.gz
+tar xf sycl_linux.tar.gz
+# Set up the expected paths
+export SYCL_BUNDLE_ROOT=$(pwd)
+export PATH=$SYCL_BUNDLE_ROOT/bin:$PATH
+export CPATH=$SYCL_BUNDLE_ROOT/include:$CPATH
+export LIBRARY_PATH=$SYCL_BUNDLE_ROOT/lib:$LIBRARY_PATH
+export LD_LIBRARY_PATH=$SYCL_BUNDLE_ROOT/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$SYCL_BUNDLE_ROOT/linux/lib/x64:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$SYCL_BUNDLE_ROOT/lib/oclgpu:$LD_LIBRARY_PATH
+
+cd /usr/local/checkbox-gfx
+git clone https://github.com/intel/level-zero-raytracing-support
+cd level-zero-raytracing-support
+mkdir build
+cd build/
+cmake -G Ninja -D CMAKE_CXX_COMPILER=clang++ -D CMAKE_C_COMPILER=clang -D CMAKE_BUILD_TYPE=Release -D ZE_RAYTRACING_SYCL_TESTS=DEFAULT_RTAS_BUILDER ..
+cmake --build . --target package
+

--- a/checkbox-provider-gfx/units/category.pxu
+++ b/checkbox-provider-gfx/units/category.pxu
@@ -2,3 +2,6 @@ unit: category
 id: level-zero
 _name: Category for Intel level zero tests
 
+unit: category
+id: level-zero-raytracing
+_name: Category for Intel level zero raytracing tests

--- a/checkbox-provider-gfx/units/jobs.pxu
+++ b/checkbox-provider-gfx/units/jobs.pxu
@@ -314,6 +314,85 @@ command:
     echo 'command: sudo /usr/local/checkbox-gfx/test_sysman_led_zesinit'
     echo
 
+id: levelzeroraytracingtests
+plugin: resource
+command:
+    echo 'testname: embree_rthwif_cornell_box'
+    echo 'command: embree_rthwif_cornell_box --default-rtas-builder --compare cornell_box_reference.tga'
+    echo
+    echo 'testname: rthwif_test_builder_triangles_expected'
+    echo 'command: embree_rthwif_test --default-rtas-builder --build_test_triangles --build_mode_expected'
+    echo
+    echo 'testname: rthwif_test_builder_procedurals_expected'
+    echo 'command: embree_rthwif_test --default-rtas-builder --build_test_procedurals --build_mode_expected'
+    echo
+    echo 'testname: rthwif_test_builder_instances_expected'
+    echo 'command: embree_rthwif_test --default-rtas-builder --build_test_instances --build_mode_expected'
+    echo
+    echo 'testname: rthwif_test_builder_mixed_expected'
+    echo 'command: embree_rthwif_test --default-rtas-builder --build_test_mixed --build_mode_expected'
+    echo
+    echo 'testname: rthwif_test_benchmark_triangles'
+    echo 'command: embree_rthwif_test --default-rtas-builder --benchmark_triangles'
+    echo
+    echo 'testname: rthwif_test_benchmark_procedurals'
+    echo 'command: embree_rthwif_test --default-rtas-builder --benchmark_procedurals'
+    echo
+    echo 'testname: rthwif_test_builder_triangles_worst_case'
+    echo 'command: embree_rthwif_test --default-rtas-builder --build_test_triangles --build_mode_worst_case'
+    echo
+    echo 'testname: rthwif_test_builder_procedurals_worst_case'
+    echo 'command: embree_rthwif_test --default-rtas-builder --build_test_procedurals --build_mode_worst_case'
+    echo
+    echo 'testname: rthwif_test_builder_instances_worst_case'
+    echo 'command: embree_rthwif_test --default-rtas-builder --build_test_instances --build_mode_worst_case'
+    echo
+    echo 'testname: rthwif_test_builder_mixed_worst_case'
+    echo 'command: embree_rthwif_test --default-rtas-builder --build_test_mixed --build_mode_worst_case'
+    echo
+    echo 'testname: rthwif_test_triangles_committed_hit'
+    echo 'command: embree_rthwif_test --default-rtas-builder --no-instancing --triangles-committed-hit'
+    echo
+    echo 'testname: rthwif_test_triangles_potential_hit'
+    echo 'command: embree_rthwif_test --default-rtas-builder --no-instancing --triangles-potential-hit'
+    echo
+    echo 'testname: rthwif_test_triangles_anyhit_shader_commit'
+    echo 'command: embree_rthwif_test --default-rtas-builder --no-instancing --triangles-anyhit-shader-commit'
+    echo
+    echo 'testname: rthwif_test_triangles_anyhit_shader_reject'
+    echo 'command: embree_rthwif_test --default-rtas-builder --no-instancing --triangles-anyhit-shader-reject'
+    echo
+    echo 'testname: rthwif_test_procedurals_committed_hit'
+    echo 'command: embree_rthwif_test --default-rtas-builder --no-instancing --procedurals-committed-hit'
+    echo
+    echo 'testname: rthwif_test_hwinstancing_triangles_committed_hit'
+    echo 'command: embree_rthwif_test --default-rtas-builder --hw-instancing --triangles-committed-hit'
+    echo
+    echo 'testname: rthwif_test_hwinstancing_triangles_potential_hit'
+    echo 'command: embree_rthwif_test --default-rtas-builder --hw-instancing --triangles-potential-hit'
+    echo
+    echo 'testname: rthwif_test_hwinstancing_triangles_anyhit_shader_commit'
+    echo 'command: embree_rthwif_test --default-rtas-builder --hw-instancing --triangles-anyhit-shader-commit'
+    echo
+    echo 'testname: rthwif_test_hwinstancing_procedurals_committed_hit'
+    echo 'command: embree_rthwif_test --default-rtas-builder --hw-instancing --procedurals-committed-hit'
+    echo
+    echo 'testname: rthwif_test_swinstancing_triangles_committed_hit'
+    echo 'command: embree_rthwif_test --default-rtas-builder --sw-instancing --triangles-committed-hit'
+    echo
+    echo 'testname: rthwif_test_swinstancing_triangles_potential_hit'
+    echo 'command: embree_rthwif_test --default-rtas-builder --sw-instancing --triangles-potential-hit'
+    echo
+    echo 'testname: rthwif_test_swinstancing_triangles_anyhit_shader_commit'
+    echo 'command: embree_rthwif_test --default-rtas-builder --sw-instancing --triangles-anyhit-shader-commit'
+    echo
+    echo 'testname: rthwif_test_swinstancing_triangles_anyhit_shader_reject'
+    echo 'command: embree_rthwif_test --default-rtas-builder --sw-instancing --triangles-anyhit-shader-reject'
+    echo
+    echo 'testname: rthwif_test_swinstancing_procedurals_committed_hit'
+    echo 'command: embree_rthwif_test --default-rtas-builder --sw-instancing --procedurals-committed-hit'
+    echo
+
 unit: template
 template-resource: levelzerobins
 template-filter: levelzerobins.binname != ''
@@ -331,5 +410,30 @@ environ:
   NORMAL_USER
 estimated_duration: 1m
 command:
+  echo "{{ command }}"
+  {{ command }}
+
+unit: template
+template-resource: levelzeroraytracingtests
+template-filter: levelzeroraytracingtests.testname != ''
+template-engine: jinja2
+template-unit: job
+id: gfx_level_zero_rt_{{ testname }}
+category_id: level-zero-raytracing
+flags: simple
+user: root
+_summary: Run the {{ testname }} test from level zero tests
+environ:
+  # necessary for local mode
+  XDG_SESSION_TYPE
+  XDG_RUNTIME_DIR
+  NORMAL_USER
+estimated_duration: 1m
+command:
+  SYCL_BUNDLE_ROOT=/usr/local/checkbox-gfx/sycl_linux/
+  PATH=$PATH:$SYCL_BUNDLE_ROOT/../level-zero-raytracing-support/build/
+  LD_LIBRARY_PATH=$SYCL_BUNDLE_ROOT/lib:$LD_LIBRARY_PATH
+  LD_LIBRARY_PATH=$SYCL_BUNDLE_ROOT/linux/lib/x64:$LD_LIBRARY_PATH
+  LD_LIBRARY_PATH=$SYCL_BUNDLE_ROOT/lib/oclgpu:$LD_LIBRARY_PATH
   echo "{{ command }}"
   {{ command }}

--- a/checkbox-provider-gfx/units/test-plan.pxu
+++ b/checkbox-provider-gfx/units/test-plan.pxu
@@ -3,8 +3,10 @@ unit: test plan
 _name: GFX test plan for hardware encode and decode
 include:
   gfx_level_zero.*
+  gfx_level_zero_rt.*
 bootstrap_include:
     com.canonical.certification::executable
     com.canonical.certification::snap
     graphics_card
     levelzerobins
+    levelzeroraytracingtests


### PR DESCRIPTION
All tests but `gfx_level_zero_rt_embree_rthwif_cornell_box` pass if the whole level zero stack is correctly installed via the graphics enablement PPAs