### PR TITLE
Fix level-zero-raytracing install

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -1,8 +1,11 @@
 #!/bin/bash
 
-sudo apt -y update
-sudo apt install -y build-essential cmake ocl-icd-libopencl1 libva2 libva-drm2 libze-dev libze-intel-gpu-dev libpng-dev libboost-all-dev libmfx-gen1 ninja-build
+INSTALL_DIR=/usr/local/checkbox-gfx
 
+sudo apt -y update
+sudo apt install -y build-essential cmake ocl-icd-libopencl1 libva2 libva-drm2 libze-dev libze-intel-gpu-dev libpng-dev libboost-all-dev libmfx-gen1 ninja-build clang
+
+cd $INSTALL_DIR
 git clone https://github.com/oneapi-src/level-zero-tests
 cd level-zero-tests
 git checkout cf41a5a6d220a5ca951f7d92e2d62f51d38fbb1c
@@ -10,14 +13,18 @@ wget https://people.canonical.com/~mckeesh/level-zero-tests-fix.diff
 git apply level-zero-tests-fix.diff
 mkdir build
 cd build
-cmake -D CMAKE_INSTALL_PREFIX=/usr/local/checkbox-gfx ..
+cmake -D CMAKE_INSTALL_PREFIX=$INSTALL_DIR ..
 sudo cmake --build . --config Release --target install
 
 # install level-zero-raytracing-support testing
-cd /usr/local/checkbox-gfx
+cd /tmp/
 mkdir sycl_linux && cd sycl_linux
 wget https://github.com/intel/llvm/releases/download/nightly-2024-06-10/sycl_linux.tar.gz
 tar xf sycl_linux.tar.gz
+cd ..
+sudo mv sycl_linux $INSTALL_DIR
+
+cd $INSTALL_DIR/sycl_linux
 # Set up the expected paths
 export SYCL_BUNDLE_ROOT=$(pwd)
 export PATH=$SYCL_BUNDLE_ROOT/bin:$PATH
@@ -27,11 +34,12 @@ export LD_LIBRARY_PATH=$SYCL_BUNDLE_ROOT/lib:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$SYCL_BUNDLE_ROOT/linux/lib/x64:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$SYCL_BUNDLE_ROOT/lib/oclgpu:$LD_LIBRARY_PATH
 
-cd /usr/local/checkbox-gfx
+cd /tmp/
 git clone https://github.com/intel/level-zero-raytracing-support
 cd level-zero-raytracing-support
 mkdir build
 cd build/
 cmake -G Ninja -D CMAKE_CXX_COMPILER=clang++ -D CMAKE_C_COMPILER=clang -D CMAKE_BUILD_TYPE=Release -D ZE_RAYTRACING_SYCL_TESTS=DEFAULT_RTAS_BUILDER ..
-cmake --build . --target package
-
+cmake --build . --target package && echo "Level zero raytracing build complete" || exit 1
+cd ../..
+sudo mv level-zero-raytracing-support $INSTALL_DIR

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -54,6 +54,8 @@ apps:
     command: bin/shell-wrapper
   install:
     command: bin/install
+  remove:
+    command: bin/remove
 
 passthrough:
   hooks:


### PR DESCRIPTION
There were some "Works on my machine" permissions issues with using /usr/local/checkbox-gfx which needed to be fixed. This should address those issues