### PR TITLE
Hanging test removal

### DIFF
--- a/checkbox-provider-gfx/units/jobs.pxu
+++ b/checkbox-provider-gfx/units/jobs.pxu
@@ -211,9 +211,6 @@ command:
     echo 'binname: test_ipc'
     echo 'command: sudo /usr/local/checkbox-gfx/test_ipc'
     echo
-    echo 'binname: test_sysman_frequency'
-    echo 'command: sudo /usr/local/checkbox-gfx/test_sysman_frequency'
-    echo
     echo 'binname: test_memory'
     echo 'command: sudo /usr/local/checkbox-gfx/test_memory'
     echo

--- a/checkbox-provider-gfx/units/jobs.pxu
+++ b/checkbox-provider-gfx/units/jobs.pxu
@@ -223,9 +223,6 @@ command:
     echo 'binname: test_residency'
     echo 'command: sudo /usr/local/checkbox-gfx/test_residency'
     echo
-    echo 'binname: test_sysman_scheduler'
-    echo 'command: sudo /usr/local/checkbox-gfx/test_sysman_scheduler'
-    echo
     echo 'binname: test_sysman_overclocking'
     echo 'command: sudo /usr/local/checkbox-gfx/test_sysman_overclocking'
     echo

--- a/checkbox-provider-gfx/units/jobs.pxu
+++ b/checkbox-provider-gfx/units/jobs.pxu
@@ -229,9 +229,6 @@ command:
     echo 'binname: test_cmdqueue_errors'
     echo 'command: sudo /usr/local/checkbox-gfx/test_cmdqueue_errors'
     echo
-    echo 'binname: test_sysman_frequency_zesinit'
-    echo 'command: sudo /usr/local/checkbox-gfx/test_sysman_frequency_zesinit'
-    echo
     echo 'binname: test_sysman_temperature_zesinit'
     echo 'command: sudo /usr/local/checkbox-gfx/test_sysman_temperature_zesinit'
     echo

--- a/checkbox-provider-gfx/units/jobs.pxu
+++ b/checkbox-provider-gfx/units/jobs.pxu
@@ -223,9 +223,6 @@ command:
     echo 'binname: test_residency'
     echo 'command: sudo /usr/local/checkbox-gfx/test_residency'
     echo
-    echo 'binname: test_sysman_overclocking'
-    echo 'command: sudo /usr/local/checkbox-gfx/test_sysman_overclocking'
-    echo
     echo 'binname: test_init_sysman_after_core'
     echo 'command: sudo /usr/local/checkbox-gfx/test_init_sysman_after_core'
     echo

--- a/checkbox-provider-gfx/units/jobs.pxu
+++ b/checkbox-provider-gfx/units/jobs.pxu
@@ -190,9 +190,6 @@ command:
     echo 'binname: test_event'
     echo 'command: sudo /usr/local/checkbox-gfx/test_event'
     echo
-    echo 'binname: test_stress_commands_overloading'
-    echo 'command: sudo /usr/local/checkbox-gfx/test_stress_commands_overloading'
-    echo
     echo 'binname: test_template'
     echo 'command: sudo /usr/local/checkbox-gfx/test_template'
     echo

--- a/checkbox-provider-gfx/units/jobs.pxu
+++ b/checkbox-provider-gfx/units/jobs.pxu
@@ -247,9 +247,6 @@ command:
     echo 'binname: test_sysman_led'
     echo 'command: sudo /usr/local/checkbox-gfx/test_sysman_led'
     echo
-    echo 'binname: test_api_ltracing_dynamic'
-    echo 'command: sudo /usr/local/checkbox-gfx/test_api_ltracing_dynamic'
-    echo
     echo 'binname: test_multithread'
     echo 'command: sudo /usr/local/checkbox-gfx/test_multithread'
     echo


### PR DESCRIPTION
The level zero tests do not all complete on all machines (tested independent of the Checkbox), so this PR removes all tests that were hanging on a machine with 12th Gen Intel(R) Core(TM) i7-1280P witn 16 GB RAM. 