### PR TITLE
Updated README & jobs.pxu: changes to filepath VK-GL-CTS to CL-CTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ Each category of tests is run separately:
 ```shell
 checkbox-gfx.test-lvl-zero
 checkbox-gfx.test-lvl-zero-rt
-checkbox-gfx.test-mesa
 checkbox-gfx.test-opencl
 ```
 

--- a/checkbox-provider-gfx/units/jobs.pxu
+++ b/checkbox-provider-gfx/units/jobs.pxu
@@ -473,277 +473,277 @@ id: vkconformancetests
 plugin: resource
 command:
     echo 'testgroup: api'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/api.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/api.txt'
     echo
     echo 'testgroup: binding-model'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/binding-model.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/binding-model.txt'
     echo
     echo 'testgroup: clipping'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/clipping.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/clipping.txt'
     echo
     echo 'testgroup: compute'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/compute.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/compute.txt'
     echo
     echo 'testgroup: conditional-rendering'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/conditional-rendering.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/conditional-rendering.txt'
     echo
     echo 'testgroup: depth'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/depth.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/depth.txt'
     echo
     echo 'testgroup: descriptor-indexing'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/descriptor-indexing.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/descriptor-indexing.txt'
     echo
     echo 'testgroup: device-group'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/device-group.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/device-group.txt'
     echo
     echo 'testgroup: dgc'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/dgc.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/dgc.txt'
     echo
     echo 'testgroup: draw'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/draw.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/draw.txt'
     echo
     echo 'testgroup: drm-format-modifiers'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/drm-format-modifiers.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/drm-format-modifiers.txt'
     echo
     echo 'testgroup: dynamic-rendering'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/dynamic-rendering.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/dynamic-rendering.txt'
     echo
     echo 'testgroup: dynamic-state'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/dynamic-state.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/dynamic-state.txt'
     echo
     echo 'testgroup: fragment-operations'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/fragment-operations.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/fragment-operations.txt'
     echo
     echo 'testgroup: fragment-shader-interlock'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/fragment-shader-interlock.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/fragment-shader-interlock.txt'
     echo
     echo 'testgroup: fragment-shading-barycentric'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/fragment-shading-barycentric.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/fragment-shading-barycentric.txt'
     echo
     echo 'testgroup: fragment-shading-rate'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/fragment-shading-rate.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/fragment-shading-rate.txt'
     echo
     echo 'testgroup: geometry'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/geometry.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/geometry.txt'
     echo
     echo 'testgroup: glsl'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/glsl.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/glsl.txt'
     echo
     echo 'testgroup: graphicsfuzz'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/graphicsfuzz.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/graphicsfuzz.txt'
     echo
     echo 'testgroup: image/astc-decode-mode'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/astc-decode-mode.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/astc-decode-mode.txt'
     echo
     echo 'testgroup: image/atomic-operations'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/atomic-operations.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/atomic-operations.txt'
     echo
     echo 'testgroup: image/concurrent-copy'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/concurrent-copy.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/concurrent-copy.txt'
     echo
     echo 'testgroup: image/depth-stencil-descriptor'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/depth-stencil-descriptor.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/depth-stencil-descriptor.txt'
     echo
     echo 'testgroup: image/depth-stencil-separate-access'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/depth-stencil-separate-access.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/depth-stencil-separate-access.txt'
     echo
     echo 'testgroup: image/device-scope-access'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/device-scope-access.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/device-scope-access.txt'
     echo
     echo 'testgroup: image/extend-operands-spirv1p4'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/extend-operands-spirv1p4.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/extend-operands-spirv1p4.txt'
     echo
     echo 'testgroup: image/extended-usage-bit'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/extended-usage-bit.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/extended-usage-bit.txt'
     echo
     echo 'testgroup: image/extended-usage-bit-compatibility'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/extended-usage-bit-compatibility.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/extended-usage-bit-compatibility.txt'
     echo
     echo 'testgroup: image/format-reinterpret'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/format-reinterpret.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/format-reinterpret.txt'
     echo
     echo 'testgroup: image/host-image-copy'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/host-image-copy.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/host-image-copy.txt'
     echo
     echo 'testgroup: image/image-size'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/image-size.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/image-size.txt'
     echo
     echo 'testgroup: image/load-store'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/load-store.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/load-store.txt'
     echo
     echo 'testgroup: image/load-store-lod'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/load-store-lod.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/load-store-lod.txt'
     echo
     echo 'testgroup: image/load-store-multisample'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/load-store-multisample.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/load-store-multisample.txt'
     echo
     echo 'testgroup: image/misaligned-cube'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/misaligned-cube.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/misaligned-cube.txt'
     echo
     echo 'testgroup: image/mismatched-formats'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/mismatched-formats.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/mismatched-formats.txt'
     echo
     echo 'testgroup: image/mismatched-write-op'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/mismatched-write-op.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/mismatched-write-op.txt'
     echo
     echo 'testgroup: image/mutable'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/mutable.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/mutable.txt'
     echo
     echo 'testgroup: image/nontemporal-operand'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/nontemporal-operand.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/nontemporal-operand.txt'
     echo
     echo 'testgroup: image/qualifiers'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/qualifiers.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/qualifiers.txt'
     echo
     echo 'testgroup: image/queue-transfer'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/queue-transfer.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/queue-transfer.txt'
     echo
     echo 'testgroup: image/sample-cubemap'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/sample-cubemap.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/sample-cubemap.txt'
     echo
     echo 'testgroup: image/sample-texture'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/sample-texture.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/sample-texture.txt'
     echo
     echo 'testgroup: image/store'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/store.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/store.txt'
     echo
     echo 'testgroup: image/subresource-layout'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/subresource-layout.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/subresource-layout.txt'
     echo
     echo 'testgroup: image/swapchain-mutable'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/swapchain-mutable.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/swapchain-mutable.txt'
     echo
     echo 'testgroup: image/texel-view-compatible'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/texel-view-compatible.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/texel-view-compatible.txt'
     echo
     echo 'testgroup: imageless-framebuffer'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/imageless-framebuffer.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/imageless-framebuffer.txt'
     echo
     echo 'testgroup: info'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/info.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/info.txt'
     echo
     echo 'testgroup: memory'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/memory.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/memory.txt'
     echo
     echo 'testgroup: memory-model'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/memory-model.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/memory-model.txt'
     echo
     echo 'testgroup: mesh-shader'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/mesh-shader.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/mesh-shader.txt'
     echo
     echo 'testgroup: multiview'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/multiview.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/multiview.txt'
     echo
     echo 'testgroup: pipeline/fast-linked-library'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/pipeline/fast-linked-library.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/pipeline/fast-linked-library.txt'
     echo
     echo 'testgroup: pipeline/monolithic'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/pipeline/monolithic.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/pipeline/monolithic.txt'
     echo
     echo 'testgroup: pipeline/pipeline-library'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/pipeline/pipeline-library.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/pipeline/pipeline-library.txt'
     echo
     echo 'testgroup: pipeline/shader-object-linked-binary'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/pipeline/shader-object-linked-binary.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/pipeline/shader-object-linked-binary.txt'
     echo
     echo 'testgroup: pipeline/shader-object-linked-spirv'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/pipeline/shader-object-linked-spirv.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/pipeline/shader-object-linked-spirv.txt'
     echo
     echo 'testgroup: pipeline/shader-object-unlinked-binary'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/pipeline/shader-object-unlinked-binary.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/pipeline/shader-object-unlinked-binary.txt'
     echo
     echo 'testgroup: pipeline/shader-object-unlinked-spirv'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/pipeline/shader-object-unlinked-spirv.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/pipeline/shader-object-unlinked-spirv.txt'
     echo
     echo 'testgroup: protected-memory'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/protected-memory.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/protected-memory.txt'
     echo
     echo 'testgroup: query-pool'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/query-pool.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/query-pool.txt'
     echo
     echo 'testgroup: rasterization'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/rasterization.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/rasterization.txt'
     echo
     echo 'testgroup: ray-query'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/ray-query.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/ray-query.txt'
     echo
     echo 'testgroup: ray-tracing-pipeline'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/ray-tracing-pipeline.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/ray-tracing-pipeline.txt'
     echo
     echo 'testgroup: reconvergence'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/reconvergence.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/reconvergence.txt'
     echo
     echo 'testgroup: renderpass'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/renderpass.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/renderpass.txt'
     echo
     echo 'testgroup: renderpass2'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/renderpass2.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/renderpass2.txt'
     echo
     echo 'testgroup: robustness'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/robustness.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/robustness.txt'
     echo
     echo 'testgroup: shader-object/api'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/shader-object/api.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/shader-object/api.txt'
     echo
     echo 'testgroup: shader-object/binary'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/shader-object/binary.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/shader-object/binary.txt'
     echo
     echo 'testgroup: shader-object/binding'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/shader-object/binding.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/shader-object/binding.txt'
     echo
     echo 'testgroup: shader-object/create'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/shader-object/create.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/shader-object/create.txt'
     echo
     echo 'testgroup: shader-object/link'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/shader-object/link.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/shader-object/link.txt'
     echo
     echo 'testgroup: shader-object/misc'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/shader-object/misc.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/shader-object/misc.txt'
     echo
     echo 'testgroup: shader-object/pipeline-interaction'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/shader-object/pipeline-interaction.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/shader-object/pipeline-interaction.txt'
     echo
     echo 'testgroup: shader-object/rendering'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/shader-object/rendering.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/shader-object/rendering.txt'
     echo
     echo 'testgroup: sparse-resources'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/sparse-resources.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/sparse-resources.txt'
     echo
     echo 'testgroup: spirv-assembly'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/spirv-assembly.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/spirv-assembly.txt'
     echo
     echo 'testgroup: ssbo'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/ssbo.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/ssbo.txt'
     echo
     echo 'testgroup: subgroups'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/subgroups.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/subgroups.txt'
     echo
     echo 'testgroup: synchronization'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/synchronization.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/synchronization.txt'
     echo
     echo 'testgroup: synchronization2'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/synchronization2.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/synchronization2.txt'
     echo
     echo 'testgroup: tessellation'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/tessellation.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/tessellation.txt'
     echo
     echo 'testgroup: texture'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/texture.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/texture.txt'
     echo
     echo 'testgroup: transform-feedback'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/transform-feedback.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/transform-feedback.txt'
     echo
     echo 'testgroup: ubo'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/ubo.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/ubo.txt'
     echo
     echo 'testgroup: video'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/video.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/video.txt'
     echo
     echo 'testgroup: wsi'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/wsi.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/wsi.txt'
     echo
     echo 'testgroup: ycbcr'
-    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/ycbcr.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/ycbcr.txt'
     echo
 
 id: glconformancetests
@@ -1106,14 +1106,14 @@ id: gfx_mesa_vk_{{ testgroup }}
 category_id: mesa
 flags: simple
 user: root
-_summary: Run the {{ testgroup }} tests from GL-CTS
+_summary: Run the {{ testgroup }} tests from VK-GL-CTS
 environ:
   # necessary for local mode
   XDG_SESSION_TYPE
   XDG_RUNTIME_DIR
 estimated_duration: 1m
 command:
-  cd /usr/local/checkbox-gfx/GL-CTS/build; ./external/vulkancts/modules/vulkan/deqp-vk --deqp-caselist-file={{ testfile }}
+  cd /usr/local/checkbox-gfx/VK-GL-CTS/build; ./external/vulkancts/modules/vulkan/deqp-vk --deqp-caselist-file={{ testfile }}
 
 plugin: resource
 id: gfx_mesa_gl_hw_render
@@ -1146,7 +1146,7 @@ category_id: mesa
 depends: gfx_mesa_gl_hw_render
 flags: simple
 user: root
-_summary: Run the {{ testgroup }} {{ openglvariant }} tests from GL-CTS
+_summary: Run the {{ testgroup }} {{ openglvariant }} tests from VK-GL-CTS
 environ: 
   # necessary for local mode
   XDG_SESSION_TYPE

--- a/checkbox-provider-gfx/units/jobs.pxu
+++ b/checkbox-provider-gfx/units/jobs.pxu
@@ -473,277 +473,277 @@ id: vkconformancetests
 plugin: resource
 command:
     echo 'testgroup: api'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/api.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/api.txt'
     echo
     echo 'testgroup: binding-model'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/binding-model.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/binding-model.txt'
     echo
     echo 'testgroup: clipping'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/clipping.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/clipping.txt'
     echo
     echo 'testgroup: compute'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/compute.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/compute.txt'
     echo
     echo 'testgroup: conditional-rendering'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/conditional-rendering.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/conditional-rendering.txt'
     echo
     echo 'testgroup: depth'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/depth.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/depth.txt'
     echo
     echo 'testgroup: descriptor-indexing'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/descriptor-indexing.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/descriptor-indexing.txt'
     echo
     echo 'testgroup: device-group'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/device-group.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/device-group.txt'
     echo
     echo 'testgroup: dgc'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/dgc.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/dgc.txt'
     echo
     echo 'testgroup: draw'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/draw.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/draw.txt'
     echo
     echo 'testgroup: drm-format-modifiers'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/drm-format-modifiers.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/drm-format-modifiers.txt'
     echo
     echo 'testgroup: dynamic-rendering'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/dynamic-rendering.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/dynamic-rendering.txt'
     echo
     echo 'testgroup: dynamic-state'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/dynamic-state.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/dynamic-state.txt'
     echo
     echo 'testgroup: fragment-operations'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/fragment-operations.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/fragment-operations.txt'
     echo
     echo 'testgroup: fragment-shader-interlock'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/fragment-shader-interlock.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/fragment-shader-interlock.txt'
     echo
     echo 'testgroup: fragment-shading-barycentric'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/fragment-shading-barycentric.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/fragment-shading-barycentric.txt'
     echo
     echo 'testgroup: fragment-shading-rate'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/fragment-shading-rate.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/fragment-shading-rate.txt'
     echo
     echo 'testgroup: geometry'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/geometry.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/geometry.txt'
     echo
     echo 'testgroup: glsl'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/glsl.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/glsl.txt'
     echo
     echo 'testgroup: graphicsfuzz'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/graphicsfuzz.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/graphicsfuzz.txt'
     echo
     echo 'testgroup: image/astc-decode-mode'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/astc-decode-mode.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/astc-decode-mode.txt'
     echo
     echo 'testgroup: image/atomic-operations'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/atomic-operations.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/atomic-operations.txt'
     echo
     echo 'testgroup: image/concurrent-copy'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/concurrent-copy.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/concurrent-copy.txt'
     echo
     echo 'testgroup: image/depth-stencil-descriptor'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/depth-stencil-descriptor.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/depth-stencil-descriptor.txt'
     echo
     echo 'testgroup: image/depth-stencil-separate-access'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/depth-stencil-separate-access.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/depth-stencil-separate-access.txt'
     echo
     echo 'testgroup: image/device-scope-access'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/device-scope-access.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/device-scope-access.txt'
     echo
     echo 'testgroup: image/extend-operands-spirv1p4'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/extend-operands-spirv1p4.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/extend-operands-spirv1p4.txt'
     echo
     echo 'testgroup: image/extended-usage-bit'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/extended-usage-bit.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/extended-usage-bit.txt'
     echo
     echo 'testgroup: image/extended-usage-bit-compatibility'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/extended-usage-bit-compatibility.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/extended-usage-bit-compatibility.txt'
     echo
     echo 'testgroup: image/format-reinterpret'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/format-reinterpret.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/format-reinterpret.txt'
     echo
     echo 'testgroup: image/host-image-copy'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/host-image-copy.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/host-image-copy.txt'
     echo
     echo 'testgroup: image/image-size'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/image-size.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/image-size.txt'
     echo
     echo 'testgroup: image/load-store'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/load-store.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/load-store.txt'
     echo
     echo 'testgroup: image/load-store-lod'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/load-store-lod.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/load-store-lod.txt'
     echo
     echo 'testgroup: image/load-store-multisample'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/load-store-multisample.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/load-store-multisample.txt'
     echo
     echo 'testgroup: image/misaligned-cube'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/misaligned-cube.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/misaligned-cube.txt'
     echo
     echo 'testgroup: image/mismatched-formats'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/mismatched-formats.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/mismatched-formats.txt'
     echo
     echo 'testgroup: image/mismatched-write-op'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/mismatched-write-op.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/mismatched-write-op.txt'
     echo
     echo 'testgroup: image/mutable'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/mutable.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/mutable.txt'
     echo
     echo 'testgroup: image/nontemporal-operand'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/nontemporal-operand.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/nontemporal-operand.txt'
     echo
     echo 'testgroup: image/qualifiers'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/qualifiers.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/qualifiers.txt'
     echo
     echo 'testgroup: image/queue-transfer'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/queue-transfer.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/queue-transfer.txt'
     echo
     echo 'testgroup: image/sample-cubemap'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/sample-cubemap.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/sample-cubemap.txt'
     echo
     echo 'testgroup: image/sample-texture'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/sample-texture.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/sample-texture.txt'
     echo
     echo 'testgroup: image/store'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/store.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/store.txt'
     echo
     echo 'testgroup: image/subresource-layout'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/subresource-layout.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/subresource-layout.txt'
     echo
     echo 'testgroup: image/swapchain-mutable'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/swapchain-mutable.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/swapchain-mutable.txt'
     echo
     echo 'testgroup: image/texel-view-compatible'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/image/texel-view-compatible.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/image/texel-view-compatible.txt'
     echo
     echo 'testgroup: imageless-framebuffer'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/imageless-framebuffer.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/imageless-framebuffer.txt'
     echo
     echo 'testgroup: info'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/info.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/info.txt'
     echo
     echo 'testgroup: memory'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/memory.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/memory.txt'
     echo
     echo 'testgroup: memory-model'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/memory-model.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/memory-model.txt'
     echo
     echo 'testgroup: mesh-shader'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/mesh-shader.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/mesh-shader.txt'
     echo
     echo 'testgroup: multiview'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/multiview.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/multiview.txt'
     echo
     echo 'testgroup: pipeline/fast-linked-library'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/pipeline/fast-linked-library.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/pipeline/fast-linked-library.txt'
     echo
     echo 'testgroup: pipeline/monolithic'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/pipeline/monolithic.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/pipeline/monolithic.txt'
     echo
     echo 'testgroup: pipeline/pipeline-library'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/pipeline/pipeline-library.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/pipeline/pipeline-library.txt'
     echo
     echo 'testgroup: pipeline/shader-object-linked-binary'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/pipeline/shader-object-linked-binary.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/pipeline/shader-object-linked-binary.txt'
     echo
     echo 'testgroup: pipeline/shader-object-linked-spirv'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/pipeline/shader-object-linked-spirv.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/pipeline/shader-object-linked-spirv.txt'
     echo
     echo 'testgroup: pipeline/shader-object-unlinked-binary'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/pipeline/shader-object-unlinked-binary.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/pipeline/shader-object-unlinked-binary.txt'
     echo
     echo 'testgroup: pipeline/shader-object-unlinked-spirv'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/pipeline/shader-object-unlinked-spirv.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/pipeline/shader-object-unlinked-spirv.txt'
     echo
     echo 'testgroup: protected-memory'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/protected-memory.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/protected-memory.txt'
     echo
     echo 'testgroup: query-pool'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/query-pool.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/query-pool.txt'
     echo
     echo 'testgroup: rasterization'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/rasterization.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/rasterization.txt'
     echo
     echo 'testgroup: ray-query'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/ray-query.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/ray-query.txt'
     echo
     echo 'testgroup: ray-tracing-pipeline'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/ray-tracing-pipeline.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/ray-tracing-pipeline.txt'
     echo
     echo 'testgroup: reconvergence'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/reconvergence.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/reconvergence.txt'
     echo
     echo 'testgroup: renderpass'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/renderpass.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/renderpass.txt'
     echo
     echo 'testgroup: renderpass2'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/renderpass2.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/renderpass2.txt'
     echo
     echo 'testgroup: robustness'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/robustness.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/robustness.txt'
     echo
     echo 'testgroup: shader-object/api'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/shader-object/api.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/shader-object/api.txt'
     echo
     echo 'testgroup: shader-object/binary'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/shader-object/binary.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/shader-object/binary.txt'
     echo
     echo 'testgroup: shader-object/binding'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/shader-object/binding.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/shader-object/binding.txt'
     echo
     echo 'testgroup: shader-object/create'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/shader-object/create.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/shader-object/create.txt'
     echo
     echo 'testgroup: shader-object/link'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/shader-object/link.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/shader-object/link.txt'
     echo
     echo 'testgroup: shader-object/misc'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/shader-object/misc.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/shader-object/misc.txt'
     echo
     echo 'testgroup: shader-object/pipeline-interaction'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/shader-object/pipeline-interaction.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/shader-object/pipeline-interaction.txt'
     echo
     echo 'testgroup: shader-object/rendering'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/shader-object/rendering.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/shader-object/rendering.txt'
     echo
     echo 'testgroup: sparse-resources'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/sparse-resources.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/sparse-resources.txt'
     echo
     echo 'testgroup: spirv-assembly'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/spirv-assembly.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/spirv-assembly.txt'
     echo
     echo 'testgroup: ssbo'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/ssbo.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/ssbo.txt'
     echo
     echo 'testgroup: subgroups'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/subgroups.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/subgroups.txt'
     echo
     echo 'testgroup: synchronization'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/synchronization.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/synchronization.txt'
     echo
     echo 'testgroup: synchronization2'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/synchronization2.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/synchronization2.txt'
     echo
     echo 'testgroup: tessellation'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/tessellation.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/tessellation.txt'
     echo
     echo 'testgroup: texture'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/texture.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/texture.txt'
     echo
     echo 'testgroup: transform-feedback'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/transform-feedback.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/transform-feedback.txt'
     echo
     echo 'testgroup: ubo'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/ubo.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/ubo.txt'
     echo
     echo 'testgroup: video'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/video.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/video.txt'
     echo
     echo 'testgroup: wsi'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/wsi.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/wsi.txt'
     echo
     echo 'testgroup: ycbcr'
-    echo 'testfile: /usr/local/checkbox-gfx/VK-GL-CTS/external/vulkancts/mustpass/main/vk-default/ycbcr.txt'
+    echo 'testfile: /usr/local/checkbox-gfx/GL-CTS/external/vulkancts/mustpass/main/vk-default/ycbcr.txt'
     echo
 
 id: glconformancetests
@@ -1106,14 +1106,14 @@ id: gfx_mesa_vk_{{ testgroup }}
 category_id: mesa
 flags: simple
 user: root
-_summary: Run the {{ testgroup }} tests from VK-GL-CTS
+_summary: Run the {{ testgroup }} tests from GL-CTS
 environ:
   # necessary for local mode
   XDG_SESSION_TYPE
   XDG_RUNTIME_DIR
 estimated_duration: 1m
 command:
-  cd /usr/local/checkbox-gfx/VK-GL-CTS/build; ./external/vulkancts/modules/vulkan/deqp-vk --deqp-caselist-file={{ testfile }}
+  cd /usr/local/checkbox-gfx/GL-CTS/build; ./external/vulkancts/modules/vulkan/deqp-vk --deqp-caselist-file={{ testfile }}
 
 plugin: resource
 id: gfx_mesa_gl_hw_render
@@ -1146,14 +1146,14 @@ category_id: mesa
 depends: gfx_mesa_gl_hw_render
 flags: simple
 user: root
-_summary: Run the {{ testgroup }} {{ openglvariant }} tests from VK-GL-CTS
+_summary: Run the {{ testgroup }} {{ openglvariant }} tests from GL-CTS
 environ: 
   # necessary for local mode
   XDG_SESSION_TYPE
   XDG_RUNTIME_DIR
 estimated_duration: 1m
 command:
-  cd /usr/local/checkbox-gfx/VK-GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case={{ testfilter }}
+  cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case={{ testfilter }}
 
 plugin: resource
 id: gfx_cl_gpu_avail


### PR DESCRIPTION
1. Removed the "checkbox-gfx.test-mesa" from README as they were not required.
2. Changed file path for the opengl test from /VK-GL-CTS to /GL-CTS.